### PR TITLE
Update test configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,40 +6,35 @@ jobs:
   test_python:
     name: Python tests
 
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ["3.8", "3.9", "3.10", "3.11"]
+
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Setup Python
+      - uses: actions/checkout@v3
+      - name: Use Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
+        # specify min_version if it's defined, or default to 0
         run: |
           python -m pip install --upgrade pip
-          pip install "tox>=4.0"
-      - name: Run tox
-        run: tox -m py${{ matrix.python }}
-      - name: Upload pytest coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: pytest-coverage-results-${{ matrix.python }}
-          path: coverage.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+          MINVERSION=$(awk -F "=" "/min_version/ {print $2}" tox.ini | grep -o "[0-9.]*")
+          pip install "tox>=${MINVERSION:-0}"
+      - name: Run tests
+        run: tox -m ${{ matrix.python }}
 
   test_js:
     name: JavaScript tests
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16.x]
+
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,13 @@
 min_version = 4.0
 isolated_build = True
 envlist =
-    lint-test-type
+    static-test
 labels =
-    py3.8 = test-py38-django{22,30,31,32,40,41,42}
-    py3.9 = test-py39-django{22,30,31,32,40,41,42}
-    py3.10 = test-py310-django{32,40,41,42}
-    py3.11 = test-py311-django{41,42}, lint-type
+    # Used by .github/workflows/test.yml - envs to run for each py version
+    3.8 = test-py38-django{22,30,31,32,40,41,42}
+    3.9 = test-py39-django{22,30,31,32,40,41,42}
+    3.10 = test-py310-django{32,40,41,42}
+    3.11 = static, test-py311-django{41,42}
 
 [testenv]
 extras = test
@@ -29,9 +30,9 @@ deps =
     py310-django32: Django>=3.2.9
     py311-django41: Django>=4.1.3
 commands =
-    format: black {toxinidir} {posargs}
-    format: ruff check --select I --fix {toxinidir} {posargs}
-    lint: black {toxinidir} --check --diff {posargs}
-    lint: ruff check {toxinidir} {posargs}
-    test: pytest --cov={toxinidir} --cov-report=term --cov-report=xml {posargs}
-    type: mypy {posargs}
+    format: black {tox_root}
+    format: ruff check --select I --fix {tox_root}
+    static: black {tox_root} --check --diff
+    static: ruff check {tox_root}
+    static: mypy
+    test: pytest --cov={tox_root} --cov-report=term --cov-report=xml


### PR DESCRIPTION
A bit of gardening around the tox.ini file and GH test action:
  * Merged the lint and type testenvs into static
  * Ensured static runs first in GH Actions, so we can hit a potential failure faster
  * Simplified the tox labels
  * Removed {posargs} from the tox commands since it's easier to just invoke the commands directly if flags need to be set
  * Standardise on double quotes
  * Stop creating artifacts with coverage files - we don't use them
  * Install tox with min_version specified in tox.ini in GH action